### PR TITLE
Use custom domain name on GOV.UK PaaS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
 #gem 'govuk_tech_docs'
-gem 'dss_tech_docs'
+gem 'dss_tech_docs', '~> 0.1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
 #gem 'govuk_tech_docs'
-gem 'dss_tech_docs', '~> 0.1.1'
+gem 'dss_tech_docs', '~> 0.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (6.7.7.2)
       execjs
-    backports (3.14.0)
+    backports (3.15.0)
     chronic (0.10.2)
     chunky_png (1.3.11)
     coderay (1.1.2)
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.1.5)
     contracts (0.13.0)
     dotenv (2.7.2)
-    dss_tech_docs (0.1.0)
+    dss_tech_docs (0.1.1)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
@@ -57,8 +57,8 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.1.5)
-    ffi (1.10.0)
-    haml (5.0.4)
+    ffi (1.11.1)
+    haml (5.1.1)
       temple (>= 0.8.0)
       tilt
     hamster (3.0.0)
@@ -73,21 +73,21 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
     method_source (0.9.2)
-    middleman (4.3.3)
+    middleman (4.3.4)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
       kramdown (~> 1.2)
-      middleman-cli (= 4.3.3)
-      middleman-core (= 4.3.3)
+      middleman-cli (= 4.3.4)
+      middleman-core (= 4.3.4)
     middleman-autoprefixer (2.7.1)
       autoprefixer-rails (>= 6.5.2, < 7.0.0)
       middleman-core (>= 3.3.3)
-    middleman-cli (4.3.3)
+    middleman-cli (4.3.4)
       thor (>= 0.17.0, < 2.0)
     middleman-compass (4.0.1)
       compass (>= 1.0.0, < 2.0.0)
       middleman-core (>= 4.0.0)
-    middleman-core (4.3.3)
+    middleman-core (4.3.4)
       activesupport (>= 4.2, < 5.1)
       addressable (~> 2.3)
       backports (~> 3.6)
@@ -141,7 +141,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.0.3)
+    public_suffix (3.1.0)
     rack (2.0.7)
     rack-livereload (0.3.17)
       rack
@@ -174,7 +174,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  dss_tech_docs
+  dss_tech_docs (~> 0.1.1)
   tzinfo-data
   wdm (~> 0.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
     concurrent-ruby (1.1.5)
     contracts (0.13.0)
     dotenv (2.7.2)
-    dss_tech_docs (0.1.1)
+    dss_tech_docs (0.1.2)
       activesupport
       chronic (~> 0.10.2)
       middleman (~> 4.0)
@@ -174,7 +174,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  dss_tech_docs (~> 0.1.1)
+  dss_tech_docs (~> 0.1.2)
   tzinfo-data
   wdm (~> 0.1.0)
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,17 +1,17 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: nics-ea.london.cloudapps.digital
+host: docs.ea.digitalni.gov.uk
 
 # Header-related options
 show_govuk_logo: false
 service_name: NICS Citizen Services Architecture
 service_link: /
-phase: Alpha
+phase: Beta
 
 # Links to show on right-hand-side of header
 header_links:
-  Approach: https://dss-dev-approach.london.cloudapps.digital
-  Development: https://dss-developer-docs.london.cloudapps.digital
-  Support: https://dss-support-docs.london.cloudapps.digital
+  #Approach: https://dss-dev-approach.london.cloudapps.digital
+  #Development: https://dss-developer-docs.london.cloudapps.digital
+  #Support: https://dss-support-docs.london.cloudapps.digital
   GitHub: https://github.com/dof-dss/architecture-docs
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.

--- a/source/nginx.conf
+++ b/source/nginx.conf
@@ -60,8 +60,8 @@ http {
       <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_hsts")) %>
         add_header Strict-Transport-Security "max-age=31536000";
       <% end %>
-      if ($host != "nics-ea.london.cloudapps.digital") {
-        return 301 https://nics-ea.london.cloudapp.digital$request_uri;
+      if ($host != "docs.ea.digitalni.gov.uk") {
+        return 301 https://docs.ea.digitalni.gov.uk$request_uri;
       }
     }
 


### PR DESCRIPTION
Change to use custom domain name docs.ea.digitalni.gov.uk